### PR TITLE
Rename & clean up use of getsystem[.pl]

### DIFF
--- a/ush/global_postevents.sh
+++ b/ush/global_postevents.sh
@@ -94,7 +94,7 @@ set -u
 TIMEIT=${TIMEIT:-""}
 [ -s $DATA/time ] && TIMEIT="$DATA/time -p"
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem -tp)}
+sys_tp=${sys_tp:-$(getsystem)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
    msg="***WARNING: error using getsystem to determine system type and phase"

--- a/ush/global_postevents.sh
+++ b/ush/global_postevents.sh
@@ -94,20 +94,16 @@ set -u
 TIMEIT=${TIMEIT:-""}
 [ -s $DATA/time ] && TIMEIT="$DATA/time -p"
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem.pl -tp)}
+sys_tp=${sys_tp:-$(getsystem -tp)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
-   msg="***WARNING: error using getsystem.pl to determine system type and phase"
+   msg="***WARNING: error using getsystem to determine system type and phase"
    set +u
    [ -n "$jlogfile" ] && $DATA/postmsg "$jlogfile" "$msg"
    set -u
 fi
 echo sys_tp is set to: $sys_tp
-if [ "$sys_tp" = "Cray-XC40" -o "$SITE" = "SURGE" -o "$SITE" = "LUNA" ]; then
-  launcher_PSTX=${launcher_PSTX:-"aprun -n 1 -N 1 -d 1"}
-else
-  launcher_PSTX=${launcher_PSTX:-""}
-fi
+launcher_PSTX=${launcher_PSTX:-""}
 $TIMEIT $launcher_PSTX $PSTX < /dev/null > outout  2> errfile
 err=$?
 ###cat errfile

--- a/ush/prepobs_makeprepbufr.sh
+++ b/ush/prepobs_makeprepbufr.sh
@@ -924,7 +924,7 @@ fi
 #  determine local system name and type if available
 #  -------------------------------------------------
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem -tp)}
+sys_tp=${sys_tp:-$(getsystem)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
    msg="***WARNING: error using getsystem to determine system type and phase"

--- a/ush/prepobs_makeprepbufr.sh
+++ b/ush/prepobs_makeprepbufr.sh
@@ -363,7 +363,7 @@
 #     SITE          Site name (may have been set by local shell startup script)
 #                   Default is ""
 #     sys_tp        System type and phase.  If not imported, an attempt is made
-#                   to set it using getsystem.pl (an NCO prod_util script).
+#                   to set it using getsystem (an NCO prod_util script).
 #                   A failed attempt results in an empty string.
 #     NEMSIO_IN     Flag that if ".true." indicates that nemsio atmospheric 
 #                   background fields will be input rather than sigio.
@@ -924,10 +924,10 @@ fi
 #  determine local system name and type if available
 #  -------------------------------------------------
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem.pl -tp)}
+sys_tp=${sys_tp:-$(getsystem -tp)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
-   msg="***WARNING: error using getsystem.pl to determine system type and phase"
+   msg="***WARNING: error using getsystem to determine system type and phase"
    [ -n "$jlogfile" ] && $DATA/postmsg "$jlogfile" "$msg"
 fi
 echo sys_tp is set to: $sys_tp

--- a/ush/prepobs_oiqcbufr.sh
+++ b/ush/prepobs_oiqcbufr.sh
@@ -85,7 +85,7 @@ if [ $getsystp_err -ne 0 ]; then
    [ -n "$jlogfile" ] && $DATA/postmsg "$jlogfile" "$msg"
 fi
 echo sys_tp is set to: $sys_tp
-launcher_OIQCX=${launcher_OIQCX:-mpirun}
+launcher_OIQCX=${launcher_OIQCX:-mpiexec}
 #########################module load ibmpe ics lsf uncomment if not in profile
 #  seems to run ok w next 10 lines commented out (even though Jack had them in
 #   his version of this script)

--- a/ush/prepobs_oiqcbufr.sh
+++ b/ush/prepobs_oiqcbufr.sh
@@ -78,7 +78,7 @@ TIMEIT=${TIMEIT:-""}
 #$TIMEIT mpirun -genvall -n $LSB_DJOB_NUMPROC -machinefile $LSB_DJOB_HOSTFILE $OIQCX > outout 2> errfile
 
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem -tp)}
+sys_tp=${sys_tp:-$(getsystem)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
    msg="***WARNING: error using getsystem to determine system type and phase"

--- a/ush/prepobs_oiqcbufr.sh
+++ b/ush/prepobs_oiqcbufr.sh
@@ -28,7 +28,7 @@ qid=$$
 #   pgmout   - string indicating path to for standard output file (skipped
 #              over by this script if not passed in)
 #   sys_tp   - system type and phase.  (if not passed in, an attempt is made to
-#              set this string using getsystem.pl, an NCO script in prod_util)
+#              set this string using getsystem, an NCO script in prod_util)
 #   SITE     - site name (may have been set by local shell startup script)
 #   launcher_OIQCX - launcher for OIQCX executable (on Cray-XC40, defaults to
 #                    aprun using 16 tasks)
@@ -78,20 +78,14 @@ TIMEIT=${TIMEIT:-""}
 #$TIMEIT mpirun -genvall -n $LSB_DJOB_NUMPROC -machinefile $LSB_DJOB_HOSTFILE $OIQCX > outout 2> errfile
 
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem.pl -tp)}
+sys_tp=${sys_tp:-$(getsystem -tp)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
-   msg="***WARNING: error using getsystem.pl to determine system type and phase"
+   msg="***WARNING: error using getsystem to determine system type and phase"
    [ -n "$jlogfile" ] && $DATA/postmsg "$jlogfile" "$msg"
 fi
 echo sys_tp is set to: $sys_tp
-if [ "$sys_tp" = "Cray-XC40" -o "$SITE" = "SURGE" -o "$SITE" = "LUNA" ]; then
-   launcher_OIQCX=${launcher_OIQCX:-"aprun -n 16 -N 16 -j 1"}  # consistent with tide/gyre
-#  launcher_OIQCX=${launcher_OIQCX:-"aprun -n 24 -N 24 -j 1"}  # slightly faster
-elif [ "$sys_tp" = Dell-p3 -o "$SITE" = VENUS -o "$SITE" = MARS ]; then
-   launcher_OIQCX=${launcher_OIQCX:-mpirun}
-else
-   launcher_OIQCX=${launcher_OIQCX:-"mpirun.lsf"}
+launcher_OIQCX=${launcher_OIQCX:-mpirun}
 #########################module load ibmpe ics lsf uncomment if not in profile
 #  seems to run ok w next 10 lines commented out (even though Jack had them in
 #   his version of this script)

--- a/ush/prepobs_syndata.sh
+++ b/ush/prepobs_syndata.sh
@@ -155,7 +155,7 @@ TIMEIT=${TIMEIT:-""}
 [ -s $DATA/time ] && TIMEIT="$DATA/time -p"
 
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem -tp)}
+sys_tp=${sys_tp:-$(getsystem)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
    msg="***WARNING: error using getsystem to determine system type and phase"

--- a/ush/prepobs_syndata.sh
+++ b/ush/prepobs_syndata.sh
@@ -55,7 +55,7 @@ set -aux
 #   pgmout   - string indicating path to for standard output file (skipped
 #              over by this script if not passed in)
 #   sys_tp   - system type and phase.  (if not passed in, an attempt is made to
-#              set this string using getsystem.pl, an NCO script in prod_util)
+#              set this string using getsystem, an NCO script in prod_util)
 #   SITE     - site name (may have been set by local shell startup script)
 #   launcher_SYNDX - launcher for SYNDX executable (on Cray-XC40, defaults to
 #                    aprun using single task)
@@ -155,18 +155,14 @@ TIMEIT=${TIMEIT:-""}
 [ -s $DATA/time ] && TIMEIT="$DATA/time -p"
 
 SITE=${SITE:-""}
-sys_tp=${sys_tp:-$(getsystem.pl -tp)}
+sys_tp=${sys_tp:-$(getsystem -tp)}
 getsystp_err=$?
 if [ $getsystp_err -ne 0 ]; then
-   msg="***WARNING: error using getsystem.pl to determine system type and phase"
+   msg="***WARNING: error using getsystem to determine system type and phase"
    [ -n "$jlogfile" ] && $DATA/postmsg "$jlogfile" "$msg"
 fi
 echo sys_tp is set to: $sys_tp
-if [ "$sys_tp" = "Cray-XC40" -o "$SITE" = "SURGE" -o "$SITE" = "LUNA" ]; then
-  launcher_SYNDX=${launcher_SYNDX:-"aprun -n 1 -N 1 -d 1"}
-else
-  launcher_SYNDX=${launcher_SYNDX:-""}
-fi
+launcher_SYNDX=${launcher_SYNDX:-""}
 $TIMEIT $launcher_SYNDX $SYNDX < $SYNDC > outout  2> errfile
 err=$?
 ###cat errfile


### PR DESCRIPTION
**getsystem.pl** is now called **getsystem** on WCOSS2, and it's part of the _prod_util_ module
**getsystem** calls were updated and use of returned value (sys_tp) was simplified w.r.t. working on WCOSS2