### PR TITLE
Feature/rel obsproc.v1.0.0 shipsb mods restricted

### DIFF
--- a/ush/bufr_prepmods.sh
+++ b/ush/bufr_prepmods.sh
@@ -145,10 +145,11 @@ for dtyp in $dtypes ; do
     mkdir -p $DBASE
 
     if [ ".$dtyp" = '.ships' -o \
-         ".$dtyp" = '.shpall' ] ; then   # restrict access to SHIPS/SHPALL directory
+         ".$dtyp" = '.shpall' -o \
+	 ".$dtyp" = '.shipsb' ] ; then   # restrict access to SHIPS/SHIPSB/SHPALL directory
       chgrp rstprod $DBASE
       chmod 750     $DBASE
-    fi # dtyp = ships/shpall
+    fi # dtyp = ships/shipsb/shpall
 
 #  run the dumpjb script for this datatype  
 #  ---------------------------------------

--- a/ush/bufr_prepmods.sh
+++ b/ush/bufr_prepmods.sh
@@ -145,8 +145,8 @@ for dtyp in $dtypes ; do
     mkdir -p $DBASE
 
     if [ ".$dtyp" = '.ships' -o \
-         ".$dtyp" = '.shpall' -o \
-	 ".$dtyp" = '.shipsb' ] ; then   # restrict access to SHIPS/SHIPSB/SHPALL directory
+         ".$dtyp" = '.shipsb' -o \
+	 ".$dtyp" = '.shpall' ] ; then   # restrict access to SHIPS/SHIPSB/SHPALL directory
       chgrp rstprod $DBASE
       chmod 750     $DBASE
     fi # dtyp = ships/shipsb/shpall
@@ -265,12 +265,12 @@ RETURN CODE $errget"
       err_grand=99
     else
       cp -p $dtyp.$cymd $DBASE/$dtyp.$cymd
-###   if [ ".$dtyp" = '.ships' ] ; then        # restrict access to SHIPS files
       if [ ".$dtyp" = '.ships' -o \
-           ".$dtyp" = '.shpall' ] ; then   # restrict access to SHIPS/SHPALL files
+	   ".$dtyp" = '.shipsb' -o \
+           ".$dtyp" = '.shpall' ] ; then   # restrict access to SHIPS/SHIPSB/SHPALL files
         chgrp rstprod $DBASE/$dtyp.$cymd
         chmod 640     $DBASE/$dtyp.$cymd
-      fi # dtyp = ships/shpall
+      fi # dtyp = ships/shipsb/shpall
       msg="program  $pgm completed normally for $cymd FOR $dtyp"
       set +x
       echo


### PR DESCRIPTION
When setting up a wcoss2 para cron for mods, I realized that the shipsb mods directory, and its content, is not restricted. It should be. I have updated the code to set this restriction. Praveen, please test this change in your mods development and review my changes. Iliana, please review and merge into the release branch. My testing reveals desired results.