### PR TITLE
rm-prep fixes

### DIFF
--- a/build-obsproc/build.sh
+++ b/build-obsproc/build.sh
@@ -13,7 +13,6 @@ target=$(echo $INSTALL_TARGET | tr [:upper:] [:lower:])
 if [[ "$target" =~ ^(wcoss2|hera|orion)$ ]]; then
   source $pkg_root/versions/build.ver
   set +x
-  module reset
   module use $pkg_root/modulefiles
   module load obsproc_$target
   module list

--- a/modulefiles/obsproc_hera.lua
+++ b/modulefiles/obsproc_hera.lua
@@ -7,6 +7,7 @@ load("cmake/3.20.1")
 prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
 load("hpc/1.1.0")
 load("hpc-intel/18.0.5.274")
+load("hpc-impi/2018.0.4")
 
 -- Load common modules for this package
 load("obsproc_common")

--- a/modulefiles/obsproc_orion.lua
+++ b/modulefiles/obsproc_orion.lua
@@ -7,6 +7,7 @@ load("cmake/3.18.1")
 prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
 load("hpc/1.1.0")
 load("hpc-intel/2018.4")
+load("hpc-impi/2018.4")
 
 -- Load common modules for this package
 load("obsproc_common")


### PR DESCRIPTION
@ShelleyMelchior-NOAA 

Start with rm-prep branch this time. This branch doesn't generate modulefiles. Should it?

Tested out on WCOSS2, Orion, and Hera.

