### PR TITLE
Add override to cdate10 variable for use outside of operations

### DIFF
--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -74,7 +74,7 @@ if [ "$DO_QC" = 'YES' -a "$CQCBUFR" = 'YES' -a -n "$COM1" -a -n "$CQCC" ]; then
    fi
 fi
 
-cdate10=`cut -c7-16 ncepdate`
+cdate10=${cdate10:-`cut -c7-16 ncepdate`}
 
 msg="CENTER TIME FOR PREPBUFR PROCESSING IS $cdate10"
 $DATA/postmsg "$jlogfile" "$msg"


### PR DESCRIPTION
This PR introduces an override for the `cdate10` variable in `scripts/exglobal_makeprepbufr.sh`.

The `cdate10` variable is currently obtained via cutting characters from `ncepdate` but `ncepdate` is not useable outside of real-time operations, on the R&D machines, nor within retrospective runs. Within the obsproc_gfs[gdas]_atmos_prep jobs the `cdate10` variable doesn't exist prior to this line in `scripts/exglobal_makeprepbufr.sh` so this override should not impact operational functionality of the obsproc package:

```
Kate.Friedman@clogin04> grep ncepdate /lfs/h1/ops/prod/output/20220502/obsproc_g*prep_00*
/lfs/h1/ops/prod/output/20220502/obsproc_gdas_atmos_prep_00.o2748797:+ 0.013s + cut -c7-16 ncepdate
/lfs/h1/ops/prod/output/20220502/obsproc_gfs_atmos_prep_00.o2742601:+ 0.013s + cut -c7-16 ncepdate
```

When searching operational obsproc_gdas_atmos_prep logs for both `ncepdate` and `cdate10` these are the first instances of both, as seen in /lfs/h1/ops/prod/output/20220502/obsproc_gdas_atmos_prep_00.o2748797:
```
+ 0.013s + cut -c7-16 ncepdate
+ 0.014s + cdate10=2022050200
```

When running obsproc within the GFS prep job the `cdate10` variable needs to be set by the GFS (via `$CDATE` or `$PDY$cyc`). Adding an override function to the `cdate10` setting provides an entry point and allows the GFS to set it at runtime via its `config.prep`. Other applications could also use this override for their needs.

The developer versions of the GFS/GDAS prep jobs are not run in operations since the obsproc_gfs[gdas]_atmos_prep jobs are run, so the sourcing of `config.prep` via the developer-environment prep job will only occur outside of operations. 

Beyond the developer GFS/GDAS prep jobs, the `config.prep` config is only sourced by the gfs[gdas]_atmos_tropcy_qc_reloc jobs in operations:
```
Kate.Friedman@clogin04:/lfs/h2/emc/global/noscrub/Kate.Friedman> grep config.prep /lfs/h1/ops/prod/output/20220502/gfs_*00.*
/lfs/h1/ops/prod/output/20220502/gfs_atmos_tropcy_qc_reloc_00.o2742194:0.535 + . /lfs/h1/ops/prod/packages/gfs.v16.2.0/parm/config/config.prep
/lfs/h1/ops/prod/output/20220502/gfs_atmos_tropcy_qc_reloc_00.o2742194:0.552 + echo 'BEGIN: config.prep'
/lfs/h1/ops/prod/output/20220502/gfs_atmos_tropcy_qc_reloc_00.o2742194:BEGIN: config.prep
/lfs/h1/ops/prod/output/20220502/gfs_atmos_tropcy_qc_reloc_00.o2742194:0.565 + echo 'END: config.prep'
/lfs/h1/ops/prod/output/20220502/gfs_atmos_tropcy_qc_reloc_00.o2742194:END: config.prep
Kate.Friedman@clogin04:/lfs/h2/emc/global/noscrub/Kate.Friedman> grep config.prep /lfs/h1/ops/prod/output/20220502/gdas_*00.*                                             
/lfs/h1/ops/prod/output/20220502/gdas_atmos_tropcy_qc_reloc_00.o2748482:0.492 + . /lfs/h1/ops/prod/packages/gfs.v16.2.0/parm/config/config.prep
/lfs/h1/ops/prod/output/20220502/gdas_atmos_tropcy_qc_reloc_00.o2748482:0.507 + echo 'BEGIN: config.prep'
/lfs/h1/ops/prod/output/20220502/gdas_atmos_tropcy_qc_reloc_00.o2748482:BEGIN: config.prep
/lfs/h1/ops/prod/output/20220502/gdas_atmos_tropcy_qc_reloc_00.o2748482:0.524 + echo 'END: config.prep'
/lfs/h1/ops/prod/output/20220502/gdas_atmos_tropcy_qc_reloc_00.o2748482:END: config.prep
```
...but the `cdate10` variable used in that job is not set in a way that setting it in `config.prep` would affect. The `scripts/exglobal_atmos_tropcy_qc_reloc.sh` script sets it this way:
```
cdate10=` ${NDATE:?} -$tmhr $PDY$cyc`
```
The `scripts/exglobal_atmos_tropcy_qc_reloc.sh` script _could_ be updated with a similar override but that's another topic and isn't necessary since it uses `$PDY$cyc`, which is available in runs outside of operations already.

Adding this override to `cdate10` is the only change needed to run the current version of obsproc outside of operations. It has been tested in cycled runs of the GFS on both Orion and WCOSS2.

This small update to add an override for the `cdate10` variable should be considered for inclusion in the `develop` branch after this but will be used via the `develop-rd` branch for now to support developer runs of the GFS outside of operations.

Refs #34 