### PR TITLE
Set obsproc_ver=v1.0 and HOMEgfs=$COMROOT/gfs/v16.2

### DIFF
--- a/triggers/jairnow_dump.wc2.pbs
+++ b/triggers/jairnow_dump.wc2.pbs
@@ -33,11 +33,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jairnow_dump.wc2.pbs
+++ b/triggers/jairnow_dump.wc2.pbs
@@ -32,7 +32,8 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
+
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para

--- a/triggers/jcdas_dump.wc2.pbs
+++ b/triggers/jcdas_dump.wc2.pbs
@@ -30,7 +30,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jcdas_dump.wc2.pbs
+++ b/triggers/jcdas_dump.wc2.pbs
@@ -31,11 +31,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jcdas_dump_post.wc2.pbs
+++ b/triggers/jcdas_dump_post.wc2.pbs
@@ -32,10 +32,11 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
 #export HOMEobsproc=${PACKAGEROOT}/${obsNET}.${obsproc_ver}      # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 

--- a/triggers/jcdas_dump_post.wc2.pbs
+++ b/triggers/jcdas_dump_post.wc2.pbs
@@ -31,7 +31,7 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 

--- a/triggers/jcdas_prep1.wc2.pbs
+++ b/triggers/jcdas_prep1.wc2.pbs
@@ -31,7 +31,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jcdas_prep1.wc2.pbs
+++ b/triggers/jcdas_prep1.wc2.pbs
@@ -32,11 +32,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jcdas_prep1_post.wc2.pbs
+++ b/triggers/jcdas_prep1_post.wc2.pbs
@@ -31,11 +31,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export obsNET=obsproc
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jcdas_prep1_post.wc2.pbs
+++ b/triggers/jcdas_prep1_post.wc2.pbs
@@ -30,7 +30,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export obsNET=obsproc
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jcdas_prep2.wc2.pbs
+++ b/triggers/jcdas_prep2.wc2.pbs
@@ -37,10 +37,11 @@ userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jcdas_prep2.wc2.pbs
+++ b/triggers/jcdas_prep2.wc2.pbs
@@ -36,7 +36,7 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para

--- a/triggers/jcdas_prep2_post.wc2.pbs
+++ b/triggers/jcdas_prep2_post.wc2.pbs
@@ -32,7 +32,7 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para

--- a/triggers/jcdas_prep2_post.wc2.pbs
+++ b/triggers/jcdas_prep2_post.wc2.pbs
@@ -33,10 +33,11 @@ userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jdump_alert.wc2.pbs
+++ b/triggers/jdump_alert.wc2.pbs
@@ -35,7 +35,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${userROOT}/obsproc-cmake/$obsproc_ver/jdumpalert  # local

--- a/triggers/jdump_alert.wc2.pbs
+++ b/triggers/jdump_alert.wc2.pbs
@@ -36,6 +36,7 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${userROOT}/obsproc-cmake/$obsproc_ver/jdumpalert  # local

--- a/triggers/jdump_monitor.wc2.pbs
+++ b/triggers/jdump_monitor.wc2.pbs
@@ -30,11 +30,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jdump_monitor.wc2.pbs
+++ b/triggers/jdump_monitor.wc2.pbs
@@ -29,7 +29,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jglobal_dump.wc2.pbs
+++ b/triggers/jglobal_dump.wc2.pbs
@@ -32,7 +32,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jglobal_dump.wc2.pbs
+++ b/triggers/jglobal_dump.wc2.pbs
@@ -33,11 +33,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jglobal_dump_post.wc2.pbs
+++ b/triggers/jglobal_dump_post.wc2.pbs
@@ -34,7 +34,7 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0.0 
+export obsproc_ver=v1.0 
 export bufr_dump_ver=1.0.0
 
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para

--- a/triggers/jglobal_dump_post.wc2.pbs
+++ b/triggers/jglobal_dump_post.wc2.pbs
@@ -34,10 +34,11 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0 
+export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0 
 export bufr_dump_ver=1.0.0
 
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
 #export HOMEobsproc=${PACKAGEROOT}/${obsNET}.${obsproc_ver}      # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 

--- a/triggers/jglobal_prep.wc2.pbs
+++ b/triggers/jglobal_prep.wc2.pbs
@@ -31,7 +31,7 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
@@ -78,7 +78,7 @@ export SENDDBN=NO   # developer
 export DATAROOT=/lfs/h2/emc/stmp/$USER
 export jlogfile=/lfs/h2/emc/stmp/$USER/${JTYP}.$PDY.jlogfile
 
-export HOMEgfs=$PACKAGEROOT/gfs.v16.2.0
+export HOMEgfs=$COMROOT/gfs/v16.2
 
 export COMIN_ROOT=/lfs/h2/emc/stmp/$USER/CRON/${DESC}/com
 #export COMINgdas=/lfs/h1/ops/canned/com/gfs/v16.2/${JTYP}.${PDY}/${cyc}/${COMPONENT}

--- a/triggers/jglobal_prep.wc2.pbs
+++ b/triggers/jglobal_prep.wc2.pbs
@@ -32,10 +32,11 @@ userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jglobal_prep_post.wc2.pbs
+++ b/triggers/jglobal_prep_post.wc2.pbs
@@ -31,7 +31,7 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0.0 
+export obsproc_ver=v1.0 
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para

--- a/triggers/jglobal_prep_post.wc2.pbs
+++ b/triggers/jglobal_prep_post.wc2.pbs
@@ -31,11 +31,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsNET=obsproc
-export obsproc_ver=v1.0 
+export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0 
 export prepobs_ver=1.0.0
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jmods.wc2.pbs
+++ b/triggers/jmods.wc2.pbs
@@ -29,11 +29,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jmods.wc2.pbs
+++ b/triggers/jmods.wc2.pbs
@@ -28,7 +28,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jnam_dump.wc2.pbs
+++ b/triggers/jnam_dump.wc2.pbs
@@ -32,7 +32,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jnam_dump.wc2.pbs
+++ b/triggers/jnam_dump.wc2.pbs
@@ -33,11 +33,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jnam_dump2.wc2.pbs
+++ b/triggers/jnam_dump2.wc2.pbs
@@ -32,7 +32,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jnam_dump2.wc2.pbs
+++ b/triggers/jnam_dump2.wc2.pbs
@@ -33,11 +33,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jnam_dump_post.wc2.pbs
+++ b/triggers/jnam_dump_post.wc2.pbs
@@ -32,7 +32,7 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jnam_dump_post.wc2.pbs
+++ b/triggers/jnam_dump_post.wc2.pbs
@@ -33,11 +33,12 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jnam_prep.wc2.pbs
+++ b/triggers/jnam_prep.wc2.pbs
@@ -36,11 +36,12 @@ export job=nam_prep_${tmmark}_${cyc}
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jnam_prep.wc2.pbs
+++ b/triggers/jnam_prep.wc2.pbs
@@ -35,7 +35,7 @@ export job=nam_prep_${tmmark}_${cyc}
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jnam_prep_post.wc2.pbs
+++ b/triggers/jnam_prep_post.wc2.pbs
@@ -33,11 +33,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jnam_prep_post.wc2.pbs
+++ b/triggers/jnam_prep_post.wc2.pbs
@@ -32,7 +32,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrap_dump.wc2.pbs
+++ b/triggers/jrap_dump.wc2.pbs
@@ -38,7 +38,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrap_dump.wc2.pbs
+++ b/triggers/jrap_dump.wc2.pbs
@@ -39,11 +39,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jrap_dump_post.wc2.pbs
+++ b/triggers/jrap_dump_post.wc2.pbs
@@ -40,7 +40,7 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrap_dump_post.wc2.pbs
+++ b/triggers/jrap_dump_post.wc2.pbs
@@ -41,11 +41,12 @@ PDYm1=$(date -d "${PDY} 1 day ago" +%Y%m%d)
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}        # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep      # local
 
 VERSION_FILE=$HOMEobsproc/versions/run.ver

--- a/triggers/jrap_prep.wc2.pbs
+++ b/triggers/jrap_prep.wc2.pbs
@@ -38,7 +38,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrap_prep.wc2.pbs
+++ b/triggers/jrap_prep.wc2.pbs
@@ -39,11 +39,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jrap_prep_post.wc2.pbs
+++ b/triggers/jrap_prep_post.wc2.pbs
@@ -36,7 +36,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrap_prep_post.wc2.pbs
+++ b/triggers/jrap_prep_post.wc2.pbs
@@ -37,11 +37,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jrtma_dump.wc2.pbs
+++ b/triggers/jrtma_dump.wc2.pbs
@@ -35,7 +35,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrtma_dump.wc2.pbs
+++ b/triggers/jrtma_dump.wc2.pbs
@@ -36,11 +36,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jrtma_dump_post.wc2.pbs
+++ b/triggers/jrtma_dump_post.wc2.pbs
@@ -34,11 +34,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 #export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para 
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para 
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jrtma_dump_post.wc2.pbs
+++ b/triggers/jrtma_dump_post.wc2.pbs
@@ -33,7 +33,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 #export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrtma_prep.wc2.pbs
+++ b/triggers/jrtma_prep.wc2.pbs
@@ -36,7 +36,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrtma_prep.wc2.pbs
+++ b/triggers/jrtma_prep.wc2.pbs
@@ -37,11 +37,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jrtma_prep_post.wc2.pbs
+++ b/triggers/jrtma_prep_post.wc2.pbs
@@ -36,7 +36,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jrtma_prep_post.wc2.pbs
+++ b/triggers/jrtma_prep_post.wc2.pbs
@@ -37,11 +37,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jurma_dump.wc2.pbs
+++ b/triggers/jurma_dump.wc2.pbs
@@ -29,11 +29,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jurma_dump.wc2.pbs
+++ b/triggers/jurma_dump.wc2.pbs
@@ -28,7 +28,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export bufr_dump_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jurma_dump_post.wc2.pbs
+++ b/triggers/jurma_dump_post.wc2.pbs
@@ -31,10 +31,11 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep     # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jurma_dump_post.wc2.pbs
+++ b/triggers/jurma_dump_post.wc2.pbs
@@ -30,7 +30,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para

--- a/triggers/jurma_prep.wc2.pbs
+++ b/triggers/jurma_prep.wc2.pbs
@@ -31,7 +31,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jurma_prep.wc2.pbs
+++ b/triggers/jurma_prep.wc2.pbs
@@ -32,11 +32,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver

--- a/triggers/jurma_prep_post.wc2.pbs
+++ b/triggers/jurma_prep_post.wc2.pbs
@@ -31,7 +31,7 @@ export PDY=%PDY%
 
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
-export obsproc_ver=v1.0.0
+export obsproc_ver=v1.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages

--- a/triggers/jurma_prep_post.wc2.pbs
+++ b/triggers/jurma_prep_post.wc2.pbs
@@ -32,11 +32,12 @@ export PDY=%PDY%
 userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
 
 export obsproc_ver=v1.0
+export obsproc_ver_pckg=v1.0.0
 export prepobs_ver=1.0.0
 export obsNET=obsproc
 PACKAGEROOTpara=/lfs/h1/ops/para/packages
-#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
-#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver_pckg}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver_pckg}       # NCO prod
 export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
 
 VERSION_FILE=${HOMEobsproc}/versions/run.ver


### PR DESCRIPTION
Replaced obsproc_ver value in all triggers
Updated HOMEgfs in jglobal_prep trigger

@AshleyStanfield-NOAA , just look at the differences as a learning exercise in PR review, and approve PR if you think all looks ok.

@ShelleyMelchior-NOAA, this branch is off /develop b/c release has more changes and I instructed the team to work off develop. 