### PR TITLE
Obsproc 'Module Load' order modifications

### DIFF
--- a/triggers/jairnow_dump.wc2.pbs
+++ b/triggers/jairnow_dump.wc2.pbs
@@ -58,6 +58,7 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jairnow_dump.wc2.pbs
+++ b/triggers/jairnow_dump.wc2.pbs
@@ -57,6 +57,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded

--- a/triggers/jairnow_dump.wc2.pbs
+++ b/triggers/jairnow_dump.wc2.pbs
@@ -52,12 +52,12 @@ fi
 # Load the modules specified in $VERSION_FILE
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jcdas_dump.wc2.pbs
+++ b/triggers/jcdas_dump.wc2.pbs
@@ -57,9 +57,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jcdas_dump.wc2.pbs
+++ b/triggers/jcdas_dump.wc2.pbs
@@ -59,9 +59,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jcdas_dump.wc2.pbs
+++ b/triggers/jcdas_dump.wc2.pbs
@@ -60,6 +60,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jcdas_dump_post.wc2.pbs
+++ b/triggers/jcdas_dump_post.wc2.pbs
@@ -61,6 +61,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jcdas_dump_post.wc2.pbs
+++ b/triggers/jcdas_dump_post.wc2.pbs
@@ -60,9 +60,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jcdas_dump_post.wc2.pbs
+++ b/triggers/jcdas_dump_post.wc2.pbs
@@ -58,9 +58,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jcdas_prep1.wc2.pbs
+++ b/triggers/jcdas_prep1.wc2.pbs
@@ -51,15 +51,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jcdas_prep1.wc2.pbs
+++ b/triggers/jcdas_prep1.wc2.pbs
@@ -56,6 +56,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jcdas_prep1.wc2.pbs
+++ b/triggers/jcdas_prep1.wc2.pbs
@@ -57,9 +57,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jcdas_prep1_post.wc2.pbs
+++ b/triggers/jcdas_prep1_post.wc2.pbs
@@ -56,9 +56,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jcdas_prep1_post.wc2.pbs
+++ b/triggers/jcdas_prep1_post.wc2.pbs
@@ -50,15 +50,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jcdas_prep1_post.wc2.pbs
+++ b/triggers/jcdas_prep1_post.wc2.pbs
@@ -55,6 +55,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jcdas_prep2.wc2.pbs
+++ b/triggers/jcdas_prep2.wc2.pbs
@@ -55,15 +55,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jcdas_prep2.wc2.pbs
+++ b/triggers/jcdas_prep2.wc2.pbs
@@ -60,6 +60,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jcdas_prep2.wc2.pbs
+++ b/triggers/jcdas_prep2.wc2.pbs
@@ -61,9 +61,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jcdas_prep2_post.wc2.pbs
+++ b/triggers/jcdas_prep2_post.wc2.pbs
@@ -51,15 +51,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jcdas_prep2_post.wc2.pbs
+++ b/triggers/jcdas_prep2_post.wc2.pbs
@@ -56,6 +56,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jcdas_prep2_post.wc2.pbs
+++ b/triggers/jcdas_prep2_post.wc2.pbs
@@ -57,9 +57,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jdump_monitor.wc2.pbs
+++ b/triggers/jdump_monitor.wc2.pbs
@@ -58,6 +58,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jdump_monitor.wc2.pbs
+++ b/triggers/jdump_monitor.wc2.pbs
@@ -55,9 +55,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jdump_monitor.wc2.pbs
+++ b/triggers/jdump_monitor.wc2.pbs
@@ -57,9 +57,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jglobal_dump.wc2.pbs
+++ b/triggers/jglobal_dump.wc2.pbs
@@ -59,9 +59,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jglobal_dump.wc2.pbs
+++ b/triggers/jglobal_dump.wc2.pbs
@@ -61,9 +61,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jglobal_dump.wc2.pbs
+++ b/triggers/jglobal_dump.wc2.pbs
@@ -62,6 +62,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jglobal_dump_post.wc2.pbs
+++ b/triggers/jglobal_dump_post.wc2.pbs
@@ -59,9 +59,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jglobal_dump_post.wc2.pbs
+++ b/triggers/jglobal_dump_post.wc2.pbs
@@ -61,9 +61,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jglobal_dump_post.wc2.pbs
+++ b/triggers/jglobal_dump_post.wc2.pbs
@@ -62,6 +62,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jglobal_prep.wc2.pbs
+++ b/triggers/jglobal_prep.wc2.pbs
@@ -56,9 +56,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jglobal_prep.wc2.pbs
+++ b/triggers/jglobal_prep.wc2.pbs
@@ -50,15 +50,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jglobal_prep.wc2.pbs
+++ b/triggers/jglobal_prep.wc2.pbs
@@ -55,6 +55,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jglobal_prep_post.wc2.pbs
+++ b/triggers/jglobal_prep_post.wc2.pbs
@@ -56,9 +56,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jglobal_prep_post.wc2.pbs
+++ b/triggers/jglobal_prep_post.wc2.pbs
@@ -50,15 +50,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jglobal_prep_post.wc2.pbs
+++ b/triggers/jglobal_prep_post.wc2.pbs
@@ -55,6 +55,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jmods.wc2.pbs
+++ b/triggers/jmods.wc2.pbs
@@ -56,6 +56,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jmods.wc2.pbs
+++ b/triggers/jmods.wc2.pbs
@@ -54,9 +54,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jnam_dump.wc2.pbs
+++ b/triggers/jnam_dump.wc2.pbs
@@ -59,9 +59,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jnam_dump.wc2.pbs
+++ b/triggers/jnam_dump.wc2.pbs
@@ -61,9 +61,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jnam_dump.wc2.pbs
+++ b/triggers/jnam_dump.wc2.pbs
@@ -62,6 +62,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jnam_dump2.wc2.pbs
+++ b/triggers/jnam_dump2.wc2.pbs
@@ -59,9 +59,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jnam_dump2.wc2.pbs
+++ b/triggers/jnam_dump2.wc2.pbs
@@ -61,9 +61,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 # use local bufr_dump installation
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jnam_dump2.wc2.pbs
+++ b/triggers/jnam_dump2.wc2.pbs
@@ -62,6 +62,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jnam_dump_post.wc2.pbs
+++ b/triggers/jnam_dump_post.wc2.pbs
@@ -59,9 +59,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jnam_dump_post.wc2.pbs
+++ b/triggers/jnam_dump_post.wc2.pbs
@@ -62,8 +62,8 @@ module load cfp/${cfp_ver}
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
-module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 #module use ${userROOT}/install/bufr_dump/modulefiles
+module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jnam_dump_post.wc2.pbs
+++ b/triggers/jnam_dump_post.wc2.pbs
@@ -61,7 +61,9 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 
 # Be sure the modules are loaded 

--- a/triggers/jnam_prep.wc2.pbs
+++ b/triggers/jnam_prep.wc2.pbs
@@ -55,15 +55,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jnam_prep.wc2.pbs
+++ b/triggers/jnam_prep.wc2.pbs
@@ -60,6 +60,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jnam_prep.wc2.pbs
+++ b/triggers/jnam_prep.wc2.pbs
@@ -61,9 +61,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jnam_prep_post.wc2.pbs
+++ b/triggers/jnam_prep_post.wc2.pbs
@@ -57,6 +57,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jnam_prep_post.wc2.pbs
+++ b/triggers/jnam_prep_post.wc2.pbs
@@ -58,9 +58,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jnam_prep_post.wc2.pbs
+++ b/triggers/jnam_prep_post.wc2.pbs
@@ -52,15 +52,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jrap_dump.wc2.pbs
+++ b/triggers/jrap_dump.wc2.pbs
@@ -67,6 +67,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jrap_dump.wc2.pbs
+++ b/triggers/jrap_dump.wc2.pbs
@@ -65,9 +65,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jrap_dump_post.wc2.pbs
+++ b/triggers/jrap_dump_post.wc2.pbs
@@ -67,9 +67,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jrap_dump_post.wc2.pbs
+++ b/triggers/jrap_dump_post.wc2.pbs
@@ -69,6 +69,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jrap_prep.wc2.pbs
+++ b/triggers/jrap_prep.wc2.pbs
@@ -58,15 +58,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jrap_prep.wc2.pbs
+++ b/triggers/jrap_prep.wc2.pbs
@@ -63,6 +63,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jrap_prep.wc2.pbs
+++ b/triggers/jrap_prep.wc2.pbs
@@ -64,9 +64,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jrap_prep_post.wc2.pbs
+++ b/triggers/jrap_prep_post.wc2.pbs
@@ -61,6 +61,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jrap_prep_post.wc2.pbs
+++ b/triggers/jrap_prep_post.wc2.pbs
@@ -56,15 +56,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jrap_prep_post.wc2.pbs
+++ b/triggers/jrap_prep_post.wc2.pbs
@@ -62,9 +62,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jrtma_dump.wc2.pbs
+++ b/triggers/jrtma_dump.wc2.pbs
@@ -62,9 +62,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jrtma_dump.wc2.pbs
+++ b/triggers/jrtma_dump.wc2.pbs
@@ -64,6 +64,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jrtma_dump_post.wc2.pbs
+++ b/triggers/jrtma_dump_post.wc2.pbs
@@ -59,9 +59,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jrtma_dump_post.wc2.pbs
+++ b/triggers/jrtma_dump_post.wc2.pbs
@@ -61,6 +61,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jrtma_prep.wc2.pbs
+++ b/triggers/jrtma_prep.wc2.pbs
@@ -61,6 +61,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jrtma_prep.wc2.pbs
+++ b/triggers/jrtma_prep.wc2.pbs
@@ -56,15 +56,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jrtma_prep.wc2.pbs
+++ b/triggers/jrtma_prep.wc2.pbs
@@ -62,9 +62,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jrtma_prep_post.wc2.pbs
+++ b/triggers/jrtma_prep_post.wc2.pbs
@@ -61,6 +61,8 @@ module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
 #module use ${userROOT}/install/prepobs/modulefiles

--- a/triggers/jrtma_prep_post.wc2.pbs
+++ b/triggers/jrtma_prep_post.wc2.pbs
@@ -56,15 +56,15 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jrtma_prep_post.wc2.pbs
+++ b/triggers/jrtma_prep_post.wc2.pbs
@@ -62,9 +62,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 

--- a/triggers/jurma_dump.wc2.pbs
+++ b/triggers/jurma_dump.wc2.pbs
@@ -57,6 +57,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jurma_dump.wc2.pbs
+++ b/triggers/jurma_dump.wc2.pbs
@@ -55,9 +55,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jurma_dump_post.wc2.pbs
+++ b/triggers/jurma_dump_post.wc2.pbs
@@ -57,6 +57,8 @@ module load cfp/${cfp_ver}
 # use para installation
 module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 

--- a/triggers/jurma_dump_post.wc2.pbs
+++ b/triggers/jurma_dump_post.wc2.pbs
@@ -55,9 +55,9 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use para installation
-module unload bufr_dump
 #module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
 # use local bufr_dump installation
+module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module use ${userROOT}/install/bufr-dump-rel.1.0.0/modulefiles
 module load bufr_dump/${bufr_dump_ver}

--- a/triggers/jurma_prep.wc2.pbs
+++ b/triggers/jurma_prep.wc2.pbs
@@ -57,12 +57,13 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
-
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jurma_prep.wc2.pbs
+++ b/triggers/jurma_prep.wc2.pbs
@@ -51,15 +51,18 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
+
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jurma_prep_post.wc2.pbs
+++ b/triggers/jurma_prep_post.wc2.pbs
@@ -63,8 +63,6 @@ module load bufr_dump/${bufr_dump_ver}
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 
-
-
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)netcdf/") -eq 0 ]]; then echo "netcdf is not loaded!"; fi

--- a/triggers/jurma_prep_post.wc2.pbs
+++ b/triggers/jurma_prep_post.wc2.pbs
@@ -51,15 +51,19 @@ fi
 #Load the modules
 module load grib_util/${grib_util_ver}
 module load netcdf/${netcdf_ver}
-module load bufr_dump/${bufr_dump_ver}
-# use local prepobs installation
-#module use ${userROOT}/install/prepobs/modulefiles
-module load prepobs/${prepobs_ver}
 module load intel/${intel_ver}
 module load craype/${craype_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
+# use local bufr_dump installation
+#module use ${userROOT}/install/bufr_dump/modulefiles
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module load prepobs/${prepobs_ver}
+
+
 
 #Check if they exist
 if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi

--- a/triggers/jurma_prep_post.wc2.pbs
+++ b/triggers/jurma_prep_post.wc2.pbs
@@ -57,9 +57,11 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 # use local bufr_dump installation
+#module unload bufr_dump
 #module use ${userROOT}/install/bufr_dump/modulefiles
 module load bufr_dump/${bufr_dump_ver}
 # use local prepobs installation
+#module unload prepobs
 #module use ${userROOT}/install/prepobs/modulefiles
 module load prepobs/${prepobs_ver}
 


### PR DESCRIPTION
Modified the order in which certain modules are loaded within several of the obsproc triggers, specifically bufr-dump and prepobs.

The following modules, if called, have been shifted toward the end of the module loading sequence:
module use ${userROOT}/GIT/bufr-dump/install/modulefiles
module load bufr_dump/${bufr_dump_ver}
module use ${userROOT}/GIT/prepobs/install/modulefiles
module load prepobs/${prepobs_ver}