### PR TITLE
Including NCO changes for consideration to be incorporated into

### DIFF
--- a/jobs/JOBSPROC_NAM_PREP
+++ b/jobs/JOBSPROC_NAM_PREP
@@ -211,7 +211,7 @@ export COMPONENT=${COMPONENT:-atmos}
 
 if [[ "$RUN_ENVIR" == nco ]]; then
   export COMIN=${COMIN:-$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${RUN}.${PDY})}
-  export COMINtcvital=${COMINtcvital:-$(compath.py ${envir}/${NET}/${nam_ver}/${RUN}.${PDY})/${cyc}/${COMPONENT}/${RUN}.${cycle}.}
+  export COMINtcvital=${COMINtcvital:-$(compath.py ${envir}/${NET}/${nam_ver}/${RUN}.${PDY})}
   export COMOUT=${COMOUT:-$(compath.py -o ${obsNET}/${obsproc_ver}/${RUN}.${PDY})}
   mkdir -m 775 -p $COMOUT
 else

--- a/scripts/exnam_makeprepbufr.sh
+++ b/scripts/exnam_makeprepbufr.sh
@@ -21,6 +21,7 @@ cat break > $pgmout
 CHGRP_RSTPROD=${CHGRP_RSTPROD:-YES}
 
 export COMSP=${COMSP:-$COMIN/${RUN}.${cycle}.}
+export COMSPtcvital=${COMSPtcvital:-$COMINtcvital/${RUN}.${cycle}.}
 
 tmhr=`echo $tmmark|cut -c3-4`
 cdate10=`$NDATE -$tmhr $PDY$cyc`

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -5,8 +5,8 @@
 export libjpeg_ver=9c
 export grib_util_ver=1.2.2
 export netcdf_ver=4.7.4
-export bufr_dump_ver=1.0.0
-export prepobs_ver=1.0.0
+export bufr_dump_ver=1.0.1
+export prepobs_ver=1.0.1
 
 export intel_ver=19.1.3.304
 export craype_ver=2.7.8
@@ -15,11 +15,14 @@ export cray_pals_ver=1.0.12
 export cfp_ver=2.0.4
 
 export gfs_ver=v16.2
+export nam_ver=v4.2
 export dictionaries_ver=v3.4.0
-export seaice_analysis_ver=v4.5
+export seaice_analysis_ver=v4.5		#engice, seaice.*5min.grb  file		
 export cdas_ver=v1.2
 export nsst_ver=v1.2	#rtgsst file
 
-export PROCESS_MASTER_SHIP_STNLST=NO
+export PROCESS_MASTER_SHIP_STNLST=NO	#for monthly gdas count (run on 2nd of Month)
 export BACK=off
 
+#export SENDSDM=NO # only YES for prod anyways
+#export TIME_CHECK=NO # dump_monitor testing


### PR DESCRIPTION
Incorporating the differences in NCO's $PACKAGEROOT/obsproc.v1.0.2 into release/obsproc.v1.0.0.

I proposed we adopt these changes now. However, the next release after WCOSS2 go-live can better address the tcvitals situation. I will create a github issue that addresses these changes better.