### PR TITLE
Fixed a bug in JOBSPROC_AIRNOW_DUMP

### DIFF
--- a/jobs/JOBSPROC_AIRNOW_DUMP
+++ b/jobs/JOBSPROC_AIRNOW_DUMP
@@ -208,8 +208,8 @@ for pdy in $PDYm1 $PDYm5; do
   export COMIN_ROOT=${COMIN_ROOT:-${COMROOT:-""}}
 
   if [ "$RUN_ENVIR" = nco ]; then
-    export COMIN=${COMIN:-$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${model}.${PDY})}
-    export COMOUT=${COMOUT:-$(compath.py -o ${obsNET}/${obsproc_ver}/${model}.${PDY})}
+    export COMIN=${COMIN:-$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${model}.${pdy})}
+    export COMOUT=${COMOUT:-$(compath.py -o ${obsNET}/${obsproc_ver}/${model}.${pdy})}
     mkdir -m 775 -p $COMOUT
   else
     export COMIN=${COMIN:-${COMIN_ROOT:?}/${obsNET}/${obsproc_ver}/${model}.${pdy}}


### PR DESCRIPTION
A bug in a "Define COM directories" section was fixed.
Pay attention to comments, and keep the use of PDY and pdy straight.