### PR TITLE
correct airnow processing when run by NCO

### DIFF
--- a/jobs/JOBSPROC_AIRNOW_DUMP
+++ b/jobs/JOBSPROC_AIRNOW_DUMP
@@ -279,8 +279,8 @@ for tmmark in tm024 tm120; do
   export COMIN_ROOT=${COMIN_ROOT:-${COMROOT:-""}}
 
   if [ "$RUN_ENVIR" = nco ]; then
-    export COMIN=${COMIN:-$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${model}.${PDY})}
-    export COMOUT=${COMOUT:-$(compath.py -o ${obsNET}/${obsproc_ver}/${model}.${PDY})}
+    export COMIN=$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${model}.${PDY})
+    export COMOUT=$(compath.py -o ${obsNET}/${obsproc_ver}/${model}.${PDY})
     mkdir -m 775 -p $COMOUT
   else
     export COMIN=${COMIN:-${COMIN_ROOT:?}/${obsNET}/${obsproc_ver}/${model}.${PDY}}

--- a/jobs/JOBSPROC_AIRNOW_DUMP
+++ b/jobs/JOBSPROC_AIRNOW_DUMP
@@ -208,8 +208,8 @@ for pdy in $PDYm1 $PDYm5; do
   export COMIN_ROOT=${COMIN_ROOT:-${COMROOT:-""}}
 
   if [ "$RUN_ENVIR" = nco ]; then
-    export COMIN=${COMIN:-$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${model}.${pdy})}
-    export COMOUT=${COMOUT:-$(compath.py -o ${obsNET}/${obsproc_ver}/${model}.${pdy})}
+    export COMIN=$(compath.py ${envir}/${obsNET}/${obsproc_ver}/${model}.${pdy})
+    export COMOUT=$(compath.py -o ${obsNET}/${obsproc_ver}/${model}.${pdy})
     mkdir -m 775 -p $COMOUT
   else
     export COMIN=${COMIN:-${COMIN_ROOT:?}/${obsNET}/${obsproc_ver}/${model}.${pdy}}


### PR DESCRIPTION
Adjust COMIN and COMOUT settings when user is NCO to not inherit previous definitions for those 2 variables.

This corrects the processing of airnow data in operations.