### PR TITLE
Feature/dev.obsproc.iss51959.nsst_subpfl :: Add subpfl and saildrone

### DIFF
--- a/build-obsproc/build.sh
+++ b/build-obsproc/build.sh
@@ -27,7 +27,7 @@ mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_INSTALL_BINDIR=exec ..
 make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
 make install
-
+exit 0
 #############################################################################
 # This section to be removed when NCO is comfortable with the typical
 # `cmake`, `make` and `make install` process.

--- a/scripts/exglobal_dump.sh
+++ b/scripts/exglobal_dump.sh
@@ -107,7 +107,7 @@ set +u
 # -----------------------------------------------------------------------------
 # Dump group #1 (non-pb, TIME_TRIM defaults to OFF) =
 #               avcsam eshrs3 ssmisu saphir atms 1bhrs4 sevcsr tesac mls
-#               esatms crisfs gsrcsr ahicsr sstvcw
+#               esatms crisfs gsrcsr ahicsr sstvcw subpfl saldrn
 #
 # Dump group #2 (pb, TIME_TRIM defaults to OFF) =
 #               sfcshp tideg atovs* adpsfc ascatt
@@ -587,6 +587,7 @@ if [ $err_check_tanks -eq 0 ];then
    DTIM_latest_atms=${DTIM_latest_atms:-"+2.99"}
 fi
 #-----------------------------------------------
+DTIM_latest_saldrn=${DTIM_latest_saldrn:-"+2.99"}
 DTIM_latest_1bhrs4=${DTIM_latest_1bhrs4:-"+2.99"}
 DTIM_latest_sevcsr=${DTIM_latest_sevcsr:-"+2.99"}
 DTIM_latest_tesac=${DTIM_latest_tesac:-"+2.99"}
@@ -630,7 +631,7 @@ DTIM_latest_sstvcw=${DTIM_latest_sstvcw:-"+2.99"}
 TIME_TRIM=${TIME_TRIM:-${TIME_TRIM1:-off}}
 
 $ushscript_dump/bufr_dump_obs.sh $dumptime 3.0 1 avcsam eshrs3 ssmisu \
- saphir $atms 1bhrs4 sevcsr tesac $mls $esatms $crisfs gsrcsr ahicsr sstvcw
+ saphir $atms 1bhrs4 sevcsr tesac $mls $esatms $crisfs gsrcsr ahicsr sstvcw subpfl saldrn
 error1=$?
 echo "$error1" > $DATA/error1
 
@@ -655,6 +656,8 @@ if [ "$SENDDBN" = "YES" ]; then
     ${COMSP}sevcsr.tm00.bufr_d
    $DBNROOT/bin/dbn_alert MODEL ${NET_uc}_BUFR_tesac $job \
     ${COMSP}tesac.tm00.bufr_d
+   $DBNROOT/bin/dbn_alert MODEL ${NET_uc}_BUFR_saldrn $job \
+    ${COMSP}saldrn.tm00.bufr_d
    if [ "$mls" = mls ];then
       $DBNROOT/bin/dbn_alert MODEL ${NET_uc}_BUFR_mls $job \
        ${COMSP}mls.tm00.bufr_d

--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -556,7 +556,7 @@ if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    err_ch=$?
    if [ $err_ch -eq 0 ]; then
 
-      DTYPS_nsst='sfcshp tesac bathy trkob'
+      DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
 
       echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
 

--- a/triggers/jglobal_dump.wc2.pbs.NSST_subpfl
+++ b/triggers/jglobal_dump.wc2.pbs.NSST_subpfl
@@ -1,0 +1,133 @@
+#!/bin/sh  
+#PBS -N obsproc_%JTYP%_dump_%PDY%_%CC%_%DESC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -l walltime=00:20:00
+#PBS -A OBSPROC-DEV
+#PBS -l place=vscatter,select=1:ncpus=14:mem=60gb
+#PBS -l debug=true
+
+##############################################
+# Submit notes:%
+# Run from [ps]tmp when running manually
+# When running from cron, output is written to /u/$USER. Bottom of trigger mv's to stmp
+# For specific PDY:
+# > jtyp=[gdas][gfs] cyc=00 PDY=20170126 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_dump.wc2.pbs
+# For latest/current PDY:
+# > jtyp=[gdas][gfs] cyc=00 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_dump.wc2.pbs
+# cycqsub location: /u/Shelley.Melchior/bin 
+##############################################
+
+set -xu
+
+export envir=prod
+
+export cyc=%CC%
+DESC=%DESC%
+JTYP=%JTYP%
+export job=${JTYP}_dump_$cyc
+export jobid=$job.$PBS_JOBID
+export PDY=%PDY%
+
+userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
+
+export obsproc_ver=v1.0
+export bufr_dump_ver=1.0.0
+export obsNET=obsproc
+PACKAGEROOTpara=/lfs/h1/ops/para/packages
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+export HOMEobsproc=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc_run.iss51959.nsst_subpfl      # local
+
+#VERSION_FILE=$HOMEobsproc/versions/run.ver
+VERSION_FILE=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc/versions/run.ver
+if [ -f $VERSION_FILE ]; then
+   . $VERSION_FILE
+else
+  echo Need version info...  Exiting...
+ exit 7
+fi
+
+# Load the modules specified in $VERSION_FILE
+module load libjpeg
+module load grib_util/${grib_util_ver}
+module load netcdf/${netcdf_ver}
+module load intel/${intel_ver}
+module load craype/${craype_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load cfp/${cfp_ver}
+# use para installation
+module unload bufr_dump
+#module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+module use ${userROOT}/githubrun/bufr_dump_run/modulefiles
+module load bufr_dump/${bufr_dump_ver}
+
+# Be sure the modules are loaded 
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)prod_util/") -eq 0 ]]; then echo "prod_util is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)prod_envir/") -eq 0 ]]; then echo "prod_envir is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)libjpeg/") -eq 0 ]]; then echo "libjpeg is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)netcdf/") -eq 0 ]]; then echo "netcdf is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)bufr_dump/") -eq 0 ]]; then echo "bufr_dump is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)intel/") -eq 0 ]]; then echo "intel is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)craype/") -eq 0 ]]; then echo "craype is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-mpich/") -eq 0 ]]; then echo "cray-mpich is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-pals/") -eq 0 ]]; then echo "cray-pals is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cfp/") -eq 0 ]]; then echo "cfp is not loaded!"; fi
+
+
+export SENDECF=NO   # developer
+export SENDDBN=NO   # developer
+export SENDSDM=NO   # developer
+
+#export TANK=$DCOMROOT
+#export TANK_000015=$DCOMROOT			#echo $DCOMROOT /lfs/h1/ops/prod/dcom   prod tanks?
+#export TANK_000015=/lfs/h1/ops/dev/dcom        #dev tanks?
+export TANK_031005=/lfs/h1/ops/dev/dcom
+ 
+
+export DATAROOT=/lfs/h2/emc/ptmp/$USER 
+export jlogfile=/lfs/h2/emc/ptmp/$USER/${JTYP}.$PDY.jlogfile
+
+export COMOUT_ROOT=${DATAROOT}/CRON/${DESC}/com
+export COMPONENT=atmos
+
+export DEBUG_LEVEL=3
+export LOUD=ON
+export KEEPDATA=YES
+
+
+$HOMEobsproc/jobs/JOBSPROC_GLOBAL_DUMP
+err=$?
+
+# When run from cron, the stdout is written to /u/$USER
+# mv to stmp
+pbsjobid=$(echo $PBS_JOBID | cut -d'.' -f1)
+cronlogfile=/u/$USER/$PBS_JOBNAME.o$pbsjobid
+#cronlogfile=/lfs/h2/emc/ptmp/$USER/$PBS_JOBNAME.o$pbsjobid
+outputdir=/lfs/h2/emc/ptmp/${USER}/CRON/${DESC}/output
+if [ -f "$cronlogfile" ]; then
+  mkdir -p $outputdir
+  mv $cronlogfile ${outputdir}/$PBS_JOBNAME.o$pbsjobid
+fi
+
+# If you wish to only run the dump job, un-comment the exit line below
+
+
+# Kick off dump_post job
+#if [ $err -eq 0 ]; then
+#  echo "submit jglobal_dump_post"
+#  jtyp=$JTYP PDY=$PDY desc=$DESC bash -l /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/cycqsub \
+#  /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/jglobal_dump_post.wc2.pbs.Sentinel_6
+#fi
+
+# Kick off prep job
+if [ $err -eq 0 ]; then
+  echo "submit jglobal_prep"
+  jtyp=$JTYP PDY=$PDY desc=$DESC bash -l /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/cycqsub \
+  /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc/triggers/jglobal_prep.wc2.pbs.NSST_subpfl
+fi
+
+exit

--- a/triggers/jglobal_dump.wc2.pbs.Sentinel_6
+++ b/triggers/jglobal_dump.wc2.pbs.Sentinel_6
@@ -1,0 +1,132 @@
+#!/bin/sh  
+#PBS -N obsproc_%JTYP%_dump_%PDY%_%CC%_%DESC%
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -l walltime=00:20:00
+#PBS -A OBSPROC-DEV
+#PBS -l place=vscatter,select=1:ncpus=14:mem=60gb
+#PBS -l debug=true
+
+##############################################
+# Submit notes:%
+# Run from [ps]tmp when running manually
+# When running from cron, output is written to /u/$USER. Bottom of trigger mv's to stmp
+# For specific PDY:
+# > jtyp=[gdas][gfs] cyc=00 PDY=20170126 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_dump.wc2.pbs
+# For latest/current PDY:
+# > jtyp=[gdas][gfs] cyc=00 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_dump.wc2.pbs
+# cycqsub location: /u/Shelley.Melchior/bin 
+##############################################
+
+set -xu
+
+export envir=prod
+
+export cyc=%CC%
+DESC=%DESC%
+JTYP=%JTYP%
+export job=${JTYP}_dump_$cyc
+export jobid=$job.$PBS_JOBID
+export PDY=%PDY%
+
+userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
+
+export obsproc_ver=v1.0
+export bufr_dump_ver=1.0.0
+export obsNET=obsproc
+PACKAGEROOTpara=/lfs/h1/ops/para/packages
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}        # NCO prod
+export HOMEobsproc=${userROOT}/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc_run_Sentinel_6_issue97485      # local
+
+#VERSION_FILE=$HOMEobsproc/versions/run.ver
+VERSION_FILE=${userROOT}/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/versions/run.ver
+if [ -f $VERSION_FILE ]; then
+   . $VERSION_FILE
+else
+  echo Need version info...  Exiting...
+ exit 7
+fi
+
+# Load the modules specified in $VERSION_FILE
+module load libjpeg
+module load grib_util/${grib_util_ver}
+module load netcdf/${netcdf_ver}
+module load intel/${intel_ver}
+module load craype/${craype_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load cfp/${cfp_ver}
+# use para installation
+module unload bufr_dump
+#module use /apps/ops/para/nco/modulefiles/compiler/intel/19.1.3.304 
+module use ${userROOT}/githubrun/bufr_dump_run/modulefiles
+module load bufr_dump/${bufr_dump_ver}
+
+# Be sure the modules are loaded 
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)prod_util/") -eq 0 ]]; then echo "prod_util is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)prod_envir/") -eq 0 ]]; then echo "prod_envir is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)libjpeg/") -eq 0 ]]; then echo "libjpeg is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)netcdf/") -eq 0 ]]; then echo "netcdf is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)bufr_dump/") -eq 0 ]]; then echo "bufr_dump is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)intel/") -eq 0 ]]; then echo "intel is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)craype/") -eq 0 ]]; then echo "craype is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-mpich/") -eq 0 ]]; then echo "cray-mpich is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-pals/") -eq 0 ]]; then echo "cray-pals is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cfp/") -eq 0 ]]; then echo "cfp is not loaded!"; fi
+
+
+export SENDECF=NO   # developer
+export SENDDBN=NO   # developer
+export SENDSDM=NO   # developer
+
+#export TANK=$DCOMROOT
+#export TANK_000015=$DCOMROOT			#echo $DCOMROOT /lfs/h1/ops/prod/dcom   prod tanks?
+#export TANK_000015=/lfs/h1/ops/dev/dcom        #dev tanks?
+export TANK_003010=/lfs/h1/ops/dev/dcom 
+
+export DATAROOT=/lfs/h2/emc/ptmp/$USER 
+export jlogfile=/lfs/h2/emc/ptmp/$USER/${JTYP}.$PDY.jlogfile
+
+export COMOUT_ROOT=${DATAROOT}/CRON/${DESC}/com
+export COMPONENT=atmos
+
+export DEBUG_LEVEL=3
+export LOUD=ON
+export KEEPDATA=YES
+
+
+$HOMEobsproc/jobs/JOBSPROC_GLOBAL_DUMP
+err=$?
+
+# When run from cron, the stdout is written to /u/$USER
+# mv to stmp
+pbsjobid=$(echo $PBS_JOBID | cut -d'.' -f1)
+cronlogfile=/u/$USER/$PBS_JOBNAME.o$pbsjobid
+#cronlogfile=/lfs/h2/emc/ptmp/$USER/$PBS_JOBNAME.o$pbsjobid
+outputdir=/lfs/h2/emc/ptmp/${USER}/CRON/${DESC}/output
+if [ -f "$cronlogfile" ]; then
+  mkdir -p $outputdir
+  mv $cronlogfile ${outputdir}/$PBS_JOBNAME.o$pbsjobid
+fi
+
+# If you wish to only run the dump job, un-comment the exit line below
+
+
+# Kick off dump_post job
+if [ $err -eq 0 ]; then
+  echo "submit jglobal_dump_post"
+  jtyp=$JTYP PDY=$PDY desc=$DESC bash -l /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/cycqsub \
+  /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/jglobal_dump_post.wc2.pbs.Sentinel_6
+fi
+
+# Kick off prep job
+if [ $err -eq 0 ]; then
+  echo "submit jglobal_prep"
+  jtyp=$JTYP PDY=$PDY desc=$DESC bash -l /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/cycqsub \
+  /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/triggers/jglobal_prep.wc2.pbs_Sentinel_6
+fi
+
+exit

--- a/triggers/jglobal_prep.wc2.pbs.NSST_subpfl
+++ b/triggers/jglobal_prep.wc2.pbs.NSST_subpfl
@@ -37,7 +37,7 @@ PACKAGEROOTpara=/lfs/h1/ops/para/packages
 #export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
 #export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
 #export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
-export HOMEobsproc=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc_run.iss51959.nsst_subpfl/scripts      # local
+export HOMEobsproc=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc_run.iss51959.nsst_subpfl      # local
 
 #VERSION_FILE=${HOMEobsproc}/versions/run.ver
 VERSION_FILE=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc/versions/run.ver

--- a/triggers/jglobal_prep.wc2.pbs.NSST_subpfl
+++ b/triggers/jglobal_prep.wc2.pbs.NSST_subpfl
@@ -1,0 +1,122 @@
+#!/bin/sh  
+#PBS -N obsproc_%JTYP%_prep_%PDY%_%CC%_%DESC%
+#PBS -j oe
+#PBS -q dev               
+#PBS -l walltime=00:20:00 
+#PBS -A OBSPROC-DEV
+#PBS -l place=vscatter,select=1:ncpus=4:mem=130gb:prepost=true
+#PBS -l debug=true
+
+##############################################
+# Submit notes:
+# Run from [ps]tmp when running manually
+# When running from cron, output is written to /u/$USER. Bottom of trigger mv's to stmp
+# For specific PDY:
+# > jtyp=gdas cyc=00 PDY=20170126 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_prep.wc2.pbs
+# For latest/current PDY:
+# > jtyp=gdas cyc=00 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_prep.wc2.pbs
+# cycqsub location: /u/Shelley.Melchior/bin 
+##############################################
+
+set -xu
+
+export envir=prod
+export cyc=%CC%
+DESC=%DESC%
+JTYP=%JTYP%
+export job=${JTYP}_prep_$cyc
+export jobid=$job.$PBS_JOBID
+export PDY=%PDY%
+
+userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
+
+export obsNET=obsproc
+export obsproc_ver=v1.0
+export prepobs_ver=1.0.0
+PACKAGEROOTpara=/lfs/h1/ops/para/packages
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
+export HOMEobsproc=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc_run.iss51959.nsst_subpfl/scripts      # local
+
+#VERSION_FILE=${HOMEobsproc}/versions/run.ver
+VERSION_FILE=${userROOT}/wrapper_scripts/JOBS/nsst_sldrn_subpfl/obsproc/versions/run.ver
+if [ -f $VERSION_FILE ]; then
+   . $VERSION_FILE
+else
+  echo Need version info...  Exiting...
+ exit 7
+fi
+
+#Load the modules
+module load grib_util/${grib_util_ver}
+module load netcdf/${netcdf_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module use /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/githubrun/prepobs_run/modulefiles
+module load prepobs/${prepobs_ver}
+module load intel/${intel_ver}
+module load craype/${craype_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load cfp/${cfp_ver}
+
+#Check if they exist
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)netcdf/") -eq 0 ]]; then echo "netcdf is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)bufr_dump/") -eq 0 ]]; then echo "bufr_dump is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)prepobs/") -eq 0 ]]; then echo "prepobs is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)intel/") -eq 0 ]]; then echo "intel is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)craype/") -eq 0 ]]; then echo "craype is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-mpich/") -eq 0 ]]; then echo "cray-mpich is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-pals/") -eq 0 ]]; then echo "cray-pals is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cfp/") -eq 0 ]]; then echo "cfp is not loaded!"; fi
+
+
+export SENDECF=NO   # developer
+export SENDSDM=NO   # developer
+export SENDDBN=NO   # developer
+
+export DATAROOT=/lfs/h2/emc/ptmp/$USER
+export jlogfile=/lfs/h2/emc/ptmp/$USER/${JTYP}.$PDY.jlogfile
+
+#export HOMEgfs=$PACKAGEROOT/gfs.v16.2.0
+export HOMEgfs=$COMROOT/gfs/v16.2
+
+export COMPONENT=atmos
+export COMIN_ROOT=/lfs/h2/emc/ptmp/$USER/CRON/${DESC}/com
+#export COMIN_ROOT=/lfs/h2/emc/ptmp/$USER/CRON/${DESC}/com/${obsNET}/${obsproc_ver}/${JTYP}.${PDY}/${cyc}/${COMPONENT}
+#export COMINgdas=/lfs/h1/ops/canned/com/gfs/v16.2/${JTYP}.${PDY}/${cyc}/${COMPONENT}
+#export COMINgfs=/lfs/h1/ops/canned/com/gfs/v16.2/${JTYP}.${PDY}/${cyc}/${COMPONENT}
+export COMOUT_ROOT=/lfs/h2/emc/ptmp/$USER/CRON/${DESC}/com
+
+export DEBUG_LEVEL=3
+export KEEPDATA=YES
+export LOUD=ON
+
+$HOMEobsproc/jobs/JOBSPROC_GLOBAL_PREP
+err=$?
+
+# When run from cron, the stdout is written to /u/$USER
+# mv to stmp
+pbsjobid=$(echo $PBS_JOBID | cut -d'.' -f1)
+cronlogfile=/u/$USER/$PBS_JOBNAME.o$pbsjobid
+outputdir=/lfs/h2/emc/ptmp/${USER}/CRON/${DESC}/output
+if [ -f "$cronlogfile" ]; then
+  mkdir -p $outputdir
+  mv $cronlogfile ${outputdir}/$PBS_JOBNAME.o$pbsjobid
+fi
+
+# If you wish to only run the prep job, un-comment the exit line below
+exit
+
+# Kick off prep_post job
+if [ $err -eq 0 ]; then
+  echo "submit jglobal_prep_post:"
+  jtyp=$JTYP PDY=$PDY desc=$DESC bash -l /u/$USER/bin/cycqsub \
+  /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/triggers/jglobal_prep_post.wc2.pbs
+fi
+
+exit
+

--- a/triggers/jglobal_prep.wc2.pbs_Sentinel_6
+++ b/triggers/jglobal_prep.wc2.pbs_Sentinel_6
@@ -1,0 +1,122 @@
+#!/bin/sh  
+#PBS -N obsproc_%JTYP%_prep_%PDY%_%CC%_%DESC%
+#PBS -j oe
+#PBS -q dev               
+#PBS -l walltime=00:20:00 
+#PBS -A OBSPROC-DEV
+#PBS -l place=vscatter,select=1:ncpus=4:mem=130gb:prepost=true
+#PBS -l debug=true
+
+##############################################
+# Submit notes:
+# Run from [ps]tmp when running manually
+# When running from cron, output is written to /u/$USER. Bottom of trigger mv's to stmp
+# For specific PDY:
+# > jtyp=gdas cyc=00 PDY=20170126 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_prep.wc2.pbs
+# For latest/current PDY:
+# > jtyp=gdas cyc=00 desc=somethingfun /u/Shelley.Melchior/bin/cycqsub /path/to/triggers/jglobal_prep.wc2.pbs
+# cycqsub location: /u/Shelley.Melchior/bin 
+##############################################
+
+set -xu
+
+export envir=prod
+export cyc=%CC%
+DESC=%DESC%
+JTYP=%JTYP%
+export job=${JTYP}_prep_$cyc
+export jobid=$job.$PBS_JOBID
+export PDY=%PDY%
+
+userROOT=/lfs/h2/emc/obsproc/noscrub/$USER
+
+export obsNET=obsproc
+export obsproc_ver=v1.0
+export prepobs_ver=1.0.0
+PACKAGEROOTpara=/lfs/h1/ops/para/packages
+#export HOMEobsproc=${PACKAGEROOTpara}/obsproc.${obsproc_ver}   # NCO para
+#export HOMEobsproc=${PACKAGEROOT}/obsproc.${obsproc_ver}       # NCO prod
+#export HOMEobsproc=${userROOT}/install/obsproc-rmprep           # local
+export HOMEobsproc=${userROOT}/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc_run_Sentinel_6_issue97485      # local
+
+#VERSION_FILE=${HOMEobsproc}/versions/run.ver
+VERSION_FILE=${userROOT}/wrapper_scripts/JOBS/Sentinel_6_issue97485/obsproc/versions/run.ver
+if [ -f $VERSION_FILE ]; then
+   . $VERSION_FILE
+else
+  echo Need version info...  Exiting...
+ exit 7
+fi
+
+#Load the modules
+module load grib_util/${grib_util_ver}
+module load netcdf/${netcdf_ver}
+module load bufr_dump/${bufr_dump_ver}
+# use local prepobs installation
+#module use ${userROOT}/install/prepobs/modulefiles
+module use /lfs/h2/emc/obsproc/noscrub/Steve.Stegall/githubrun/prepobs_run/modulefiles
+module load prepobs/${prepobs_ver}
+module load intel/${intel_ver}
+module load craype/${craype_ver}
+module load cray-mpich/${cray_mpich_ver}
+module load cray-pals/${cray_pals_ver}
+module load cfp/${cfp_ver}
+
+#Check if they exist
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)grib_util/") -eq 0 ]]; then echo "grib_util is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)netcdf/") -eq 0 ]]; then echo "netcdf is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)bufr_dump/") -eq 0 ]]; then echo "bufr_dump is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)prepobs/") -eq 0 ]]; then echo "prepobs is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)intel/") -eq 0 ]]; then echo "intel is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)craype/") -eq 0 ]]; then echo "craype is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-mpich/") -eq 0 ]]; then echo "cray-mpich is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cray-pals/") -eq 0 ]]; then echo "cray-pals is not loaded!"; fi
+if [[ $(echo $LOADEDMODULES | egrep -c "(^|:)cfp/") -eq 0 ]]; then echo "cfp is not loaded!"; fi
+
+
+export SENDECF=NO   # developer
+export SENDSDM=NO   # developer
+export SENDDBN=NO   # developer
+
+export DATAROOT=/lfs/h2/emc/ptmp/$USER
+export jlogfile=/lfs/h2/emc/ptmp/$USER/${JTYP}.$PDY.jlogfile
+
+#export HOMEgfs=$PACKAGEROOT/gfs.v16.2.0
+export HOMEgfs=$COMROOT/gfs/v16.2
+
+export COMPONENT=atmos
+export COMIN_ROOT=/lfs/h2/emc/ptmp/$USER/CRON/${DESC}/com
+#export COMIN_ROOT=/lfs/h2/emc/ptmp/$USER/CRON/${DESC}/com/${obsNET}/${obsproc_ver}/${JTYP}.${PDY}/${cyc}/${COMPONENT}
+#export COMINgdas=/lfs/h1/ops/canned/com/gfs/v16.2/${JTYP}.${PDY}/${cyc}/${COMPONENT}
+#export COMINgfs=/lfs/h1/ops/canned/com/gfs/v16.2/${JTYP}.${PDY}/${cyc}/${COMPONENT}
+export COMOUT_ROOT=/lfs/h2/emc/ptmp/$USER/CRON/${DESC}/com
+
+export DEBUG_LEVEL=3
+export KEEPDATA=YES
+export LOUD=ON
+
+$HOMEobsproc/jobs/JOBSPROC_GLOBAL_PREP
+err=$?
+
+# When run from cron, the stdout is written to /u/$USER
+# mv to stmp
+pbsjobid=$(echo $PBS_JOBID | cut -d'.' -f1)
+cronlogfile=/u/$USER/$PBS_JOBNAME.o$pbsjobid
+outputdir=/lfs/h2/emc/ptmp/${USER}/CRON/${DESC}/output
+if [ -f "$cronlogfile" ]; then
+  mkdir -p $outputdir
+  mv $cronlogfile ${outputdir}/$PBS_JOBNAME.o$pbsjobid
+fi
+
+# If you wish to only run the prep job, un-comment the exit line below
+exit
+
+# Kick off prep_post job
+if [ $err -eq 0 ]; then
+  echo "submit jglobal_prep_post:"
+  jtyp=$JTYP PDY=$PDY desc=$DESC bash -l /u/$USER/bin/cycqsub \
+  /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/triggers/jglobal_prep_post.wc2.pbs
+fi
+
+exit
+


### PR DESCRIPTION
The saildrone dumps are generated in *nsst_subpfl branch.  
The saildrone dumps are needed first in order to generate the nsst file