### PR TITLE
Add Jet build support to obsproc

### DIFF
--- a/modulefiles/obsproc_jet.lua
+++ b/modulefiles/obsproc_jet.lua
@@ -1,0 +1,17 @@
+help([[
+Load environment to build obsproc on Jet
+]])
+
+load("cmake/3.20.1")
+
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/role.epic/hpc-stack/libs/intel-18.0.5.274/modulefiles/stack")
+load("hpc/1.2.0")
+load("hpc-intel/18.0.5.274")
+load("hpc-impi/2018.4.274")
+
+-- Load common modules for this package
+load("obsproc_common")
+
+setenv("FC", "mpiifort")
+
+whatis("Description: obsproc build environment")

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -16,7 +16,7 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"$pkg_root/install"}
 BUILD_4NCO=${BUILD_4NCO:-"YES"}
 
 target=$(echo $INSTALL_TARGET | tr [:upper:] [:lower:])
-if [[ "$target" =~ ^(wcoss2|hera|orion)$ ]]; then
+if [[ "$target" =~ ^(wcoss2|hera|orion|jet)$ ]]; then
   source $pkg_root/versions/build.ver
   set +x
   module use $pkg_root/modulefiles


### PR DESCRIPTION
This PR adds build support for RDHPCS Jet in obsproc.

Changes:

- Add "jet" to target list in `ush/build.sh`.
- Create `obsproc_jet.lua` modulefile.

Closes #78