### PR TITLE
`module purge` before building

### DIFF
--- a/modulefiles/obsproc_wcoss2.lua
+++ b/modulefiles/obsproc_wcoss2.lua
@@ -8,7 +8,7 @@ cmake_ver=os.getenv("cmake_ver")
 craype_ver=os.getenv("craype_ver")
 cray_mpich_ver=os.getenv("cray_mpich_ver")
 
--- load("envvar")
+load("envvar")
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
 load(pathJoin("cmake", cmake_ver))

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -19,6 +19,7 @@ target=$(echo $INSTALL_TARGET | tr [:upper:] [:lower:])
 if [[ "$target" =~ ^(wcoss2|hera|orion|jet)$ ]]; then
   source $pkg_root/versions/build.ver
   set +x
+  module purge
   module use $pkg_root/modulefiles
   module load obsproc_$target
   module list


### PR DESCRIPTION
The environment must be pristine before building.  `module purge` ensures that.
Load `envvar` via the WCOSS2 modulefile, failing which libraries will not be found that are necessary for building.