### PR TITLE
Setup obsproc dev/gfsv17 to compile and run C96_atm3DVar CI test on Gaea-C5

### DIFF
--- a/modulefiles/obsproc_gaea.lua
+++ b/modulefiles/obsproc_gaea.lua
@@ -1,0 +1,18 @@
+help([[
+Load environment to build obsproc on Gaea
+]])
+
+prepend_path("MODULEPATH", os.getenv("spack_stack_mod_path"))
+
+stack_intel_ver=os.getenv("stack_intel_ver") or "None"
+stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "None"
+cmake_ver=os.getenv("cmake_ver") or "None"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("cmake", cmake_ver))
+
+-- Load common modules for this package
+load("obsproc_common")
+
+whatis("Description: obsproc build environment")

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -13,7 +13,7 @@ INSTALL_TARGET=${INSTALL_TARGET:-"wcoss2"}
 INSTALL_PREFIX=${INSTALL_PREFIX:-"${pkg_root}/install"}
 
 target="${INSTALL_TARGET,,}"
-if [[ "${target}" =~ ^(wcoss2|hera|orion|jet|hercules)$ ]]; then
+if [[ "${target}" =~ ^(wcoss2|hera|orion|jet|hercules|gaea)$ ]]; then
   # prepare the target specific build.ver and run.ver
   cd "${pkg_root}/versions" || exit 1
   rm -f build.ver run.ver

--- a/versions/build.gaea.ver
+++ b/versions/build.gaea.ver
@@ -1,0 +1,4 @@
+export stack_intel_ver=2023.1.0
+export stack_cray_mpich_ver=8.1.25
+source "${HOMEobsproc:-}/versions/spack.ver"
+export spack_stack_mod_path="/ncrc/proj/epic/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}-dev/install/modulefiles/Core"

--- a/versions/run.gaea.ver
+++ b/versions/run.gaea.ver
@@ -1,0 +1,4 @@
+export stack_intel_ver=2023.1.0
+export stack_cray_mpich_ver=8.1.25
+source "${HOMEobsproc:-}/versions/spack.ver"
+export spack_stack_mod_path="/ncrc/proj/epic/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}-dev/install/modulefiles/Core"


### PR DESCRIPTION
Update build files and add Gaea-specific module files to compile and run obsproc branch dev/gfsv17 C96_atm3DVar on Gaea-C5

Ref #94 
Ref NOAA-EMC/global-workflow [#2766](https://github.com/NOAA-EMC/global-workflow/issues/2766)