### PR TITLE
Update CHGRP_RSTPROD check for MAKE_NSSTBUFR

### DIFF
--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -553,44 +553,45 @@ fi  # end [ "$DO_QC" = 'YES' ]
 ## create combined ocean data dump file expected by NSST
 if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    > nsstbufr
-   chgrp rstprod nsstbufr
-   err_ch=$?
-   if [ $err_ch -eq 0 ]; then
+   
+   DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
 
-      DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
+   echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
 
-      echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
+   for type in $DTYPS_nsst ; do
+      if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
+         file=${tstsp}$type.$tmmark.bufr_d
+      elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
+         file=${COMSP}$type.$tmmark.bufr_d
+      fi
 
-      for type in $DTYPS_nsst ; do
-         if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
-            file=${tstsp}$type.$tmmark.bufr_d
-         elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
-            file=${COMSP}$type.$tmmark.bufr_d
+      if [ -s $file ]; then
+           cat $file >> nsstbufr
+           err_cat=$?
+         if [ $err_cat -ne 0 ]; then
+           msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
+           $DATA/postmsg "$jlogfile" "$msg"
          fi
+      else
+         echo $file is empty or does not exist
+      fi # [ -s $file ]
 
-         if [ -s $file ]; then
-              cat $file >> nsstbufr
-              err_cat=$?
-            if [ $err_cat -ne 0 ]; then
-              msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
-              $DATA/postmsg "$jlogfile" "$msg"
-            fi
-         else
-            echo $file is empty or does not exist
-         fi # [ -s $file ]
+   done # for type in $DTYPS_nsst 
+   
+   cp nsstbufr $COMOUT/${RUN}.${cycle}.nsstbufr
+   chmod 664 $COMOUT/${RUN}.${cycle}.nsstbufr
 
-      done # for type in $DTYPS_nsst 
-
-      cp nsstbufr $COMOUT/${RUN}.${cycle}.nsstbufr
+   if [ "$CHGRP_RSTPROD" = 'YES' ]; then
       chgrp rstprod $COMOUT/${RUN}.${cycle}.nsstbufr
-      chmod 640 $COMOUT/${RUN}.${cycle}.nsstbufr
-      msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
-rstprod group have read permission"
-      $DATA/postmsg "$jlogfile" "$msg"
-   else
-      cp /dev/null $COMOUT/${RUN}.${cycle}.nsstbufr
-      warning=yes
-   fi # if [ $err_ch -eq 0 ]
+      err_ch=$?
+      if [ $err_ch -eq 0 ]; then
+         chmod 640 $COMOUT/${RUN}.${cycle}.nsstbufr
+      else
+         cp /dev/null $COMOUT/${RUN}.${cycle}.nsstbufr
+         warning=yes
+      fi # if [ $err_ch -eq 0 ]
+   fi # if [ "CHGRP_RSTPROD" = 'YES' ]
+
 fi # if [[ "$MAKE_NSSTBUFR" == 'YES' ]]
 
 if [ "$warning" = 'yes' ]; then

--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -566,7 +566,7 @@ if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
       DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
 
       echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
-    
+
       for type in $DTYPS_nsst ; do
          if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
             file=${tstsp}$type.$tmmark.bufr_d
@@ -588,9 +588,11 @@ if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
       done # for type in $DTYPS_nsst
 
       chmod 640 nsstbufr
-      msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
+      if [ "$CHGRP_RSTPROD" = 'YES' ]; then
+         msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
 rstprod group have read permission"
-      $DATA/postmsg "$jlogfile" "$msg"
+         $DATA/postmsg "$jlogfile" "$msg"
+      fi
    else
       warning=yes
    fi # [ $err_ch -eq 0 ]

--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -553,47 +553,49 @@ fi  # end [ "$DO_QC" = 'YES' ]
 ## create combined ocean data dump file expected by NSST
 if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    > nsstbufr
-
-   DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
-
-   echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
-    
-   for type in $DTYPS_nsst ; do
-      if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
-         file=${tstsp}$type.$tmmark.bufr_d
-      elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
-         file=${COMSP}$type.$tmmark.bufr_d
-      fi
-
-      if [ -s $file ]; then
-           cat $file >> nsstbufr
-           err_cat=$?
-        if [ $err_cat -ne 0 ]; then
-           msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
-           $DATA/postmsg "$jlogfile" "$msg"
-         fi
-      else
-         echo $file is empty or does not exist
-      fi # [ -s $file ]
-
-   done # for type in $DTYPS_nsst
+   chmod 664 nsstbufr
    
-   cp nsstbufr $COMOUT/${RUN}.${cycle}.nsstbufr
-   chmod 664 $COMOUT/${RUN}.${cycle}.nsstbufr
-
+   err_ch=0 # allowing nsstbufr file be created on machines that do not support rstprod
    if [ "$CHGRP_RSTPROD" = 'YES' ]; then
-      chgrp rstprod $COMOUT/${RUN}.${cycle}.nsstbufr
+      chgrp rstprod nsstbufr
       err_ch=$?
-      if [ $err_ch -eq 0 ]; then
-         chmod 640 $COMOUT/${RUN}.${cycle}.nsstbufr
-	 msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
+   fi
+
+   if [ $err_ch -eq 0 ]; then
+
+      DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
+
+      echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
+    
+      for type in $DTYPS_nsst ; do
+         if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
+            file=${tstsp}$type.$tmmark.bufr_d
+         elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
+            file=${COMSP}$type.$tmmark.bufr_d
+         fi
+
+         if [ -s $file ]; then
+              cat $file >> nsstbufr
+              err_cat=$?
+           if [ $err_cat -ne 0 ]; then
+              msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
+              $DATA/postmsg "$jlogfile" "$msg"
+           fi
+         else
+            echo $file is empty or does not exist
+         fi # [ -s $file ]
+
+      done # for type in $DTYPS_nsst
+
+      chmod 640 nsstbufr
+      msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
 rstprod group have read permission"
-         $DATA/postmsg "$jlogfile" "$msg"
-      else
-	 cp /dev/null $COMOUT/${RUN}.${cycle}.nsstbufr
-	 warning=yes
-      fi
-   fi # if [ "CHGRP_RSTPROD" = 'YES' ]
+      $DATA/postmsg "$jlogfile" "$msg"
+   else
+      warning=yes
+   fi # [ $err_ch -eq 0 ]
+   
+   cp -p nsstbufr $COMOUT/${RUN}.${cycle}.nsstbufr
 
 fi # if [[ "$MAKE_NSSTBUFR" == 'YES' ]]
 

--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -553,7 +553,6 @@ fi  # end [ "$DO_QC" = 'YES' ]
 ## create combined ocean data dump file expected by NSST
 if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    > nsstbufr
-   chmod 664 nsstbufr
 
    DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
 
@@ -583,17 +582,14 @@ if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    chmod 664 $COMOUT/${RUN}.${cycle}.nsstbufr
 
    if [ "$CHGRP_RSTPROD" = 'YES' ]; then
-      chgrp rstprod nsstbufr
       chgrp rstprod $COMOUT/${RUN}.${cycle}.nsstbufr
       err_ch=$?
       if [ $err_ch -eq 0 ]; then
-	 chmod 640 nsstbufr
          chmod 640 $COMOUT/${RUN}.${cycle}.nsstbufr
 	 msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
 rstprod group have read permission"
          $DATA/postmsg "$jlogfile" "$msg"
       else
-         cp /dev/null nsstbufr
 	 cp /dev/null $COMOUT/${RUN}.${cycle}.nsstbufr
 	 warning=yes
       fi

--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -553,30 +553,41 @@ fi  # end [ "$DO_QC" = 'YES' ]
 ## create combined ocean data dump file expected by NSST
 if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    > nsstbufr
-   
-   DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
-
-   echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
-
-   for type in $DTYPS_nsst ; do
-      if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
-         file=${tstsp}$type.$tmmark.bufr_d
-      elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
-         file=${COMSP}$type.$tmmark.bufr_d
+   if [ "$CHGRP_RSTPROD" = 'YES' ]; then
+      chgrp rstprod nsstbufr
+      err_ch=$?
+      if [ $err_ch -ne 0 ]; then
+         cp /dev/null nsstbufr
+	 warning=yes
       fi
+   fi # [ "$CHGRP_RSTPROD" = 'YES' ]
 
-      if [ -s $file ]; then
-           cat $file >> nsstbufr
-           err_cat=$?
-         if [ $err_cat -ne 0 ]; then
-           msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
-           $DATA/postmsg "$jlogfile" "$msg"
+   if [ -s nsstbufr ]; then
+   
+      DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
+
+      echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
+
+      for type in $DTYPS_nsst ; do
+         if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
+            file=${tstsp}$type.$tmmark.bufr_d
+         elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
+            file=${COMSP}$type.$tmmark.bufr_d
          fi
-      else
-         echo $file is empty or does not exist
-      fi # [ -s $file ]
 
-   done # for type in $DTYPS_nsst 
+         if [ -s $file ]; then
+              cat $file >> nsstbufr
+              err_cat=$?
+            if [ $err_cat -ne 0 ]; then
+              msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
+              $DATA/postmsg "$jlogfile" "$msg"
+            fi
+         else
+            echo $file is empty or does not exist
+         fi # [ -s $file ]
+
+      done # for type in $DTYPS_nsst
+   fi # [ -s nsstbufr ] 
    
    cp nsstbufr $COMOUT/${RUN}.${cycle}.nsstbufr
    chmod 664 $COMOUT/${RUN}.${cycle}.nsstbufr
@@ -586,10 +597,10 @@ if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
       err_ch=$?
       if [ $err_ch -eq 0 ]; then
          chmod 640 $COMOUT/${RUN}.${cycle}.nsstbufr
-      else
-         cp /dev/null $COMOUT/${RUN}.${cycle}.nsstbufr
-         warning=yes
-      fi # if [ $err_ch -eq 0 ]
+	 msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
+rstprod group have read permission"
+         $DATA/postmsg "$jlogfile" "$msg"
+      fi
    fi # if [ "CHGRP_RSTPROD" = 'YES' ]
 
 fi # if [[ "$MAKE_NSSTBUFR" == 'YES' ]]

--- a/scripts/exglobal_makeprepbufr.sh
+++ b/scripts/exglobal_makeprepbufr.sh
@@ -553,53 +553,49 @@ fi  # end [ "$DO_QC" = 'YES' ]
 ## create combined ocean data dump file expected by NSST
 if [[ "$MAKE_NSSTBUFR" == 'YES' ]]; then
    > nsstbufr
-   if [ "$CHGRP_RSTPROD" = 'YES' ]; then
-      chgrp rstprod nsstbufr
-      err_ch=$?
-      if [ $err_ch -ne 0 ]; then
-         cp /dev/null nsstbufr
-	 warning=yes
+   chmod 664 nsstbufr
+
+   DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
+
+   echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
+    
+   for type in $DTYPS_nsst ; do
+      if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
+         file=${tstsp}$type.$tmmark.bufr_d
+      elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
+         file=${COMSP}$type.$tmmark.bufr_d
       fi
-   fi # [ "$CHGRP_RSTPROD" = 'YES' ]
 
-   if [ -s nsstbufr ]; then
-   
-      DTYPS_nsst='sfcshp tesac bathy trkob subpfl saldrn'
-
-      echo "xglm: DTYPS_nsst='$DTYPS_nsst'"
-
-      for type in $DTYPS_nsst ; do
-         if [ -f ${tstsp}$type.$tmmark.bufr_d ]; then
-            file=${tstsp}$type.$tmmark.bufr_d
-         elif [ -s ${COMSP}$type.$tmmark.bufr_d ]; then
-            file=${COMSP}$type.$tmmark.bufr_d
+      if [ -s $file ]; then
+           cat $file >> nsstbufr
+           err_cat=$?
+        if [ $err_cat -ne 0 ]; then
+           msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
+           $DATA/postmsg "$jlogfile" "$msg"
          fi
+      else
+         echo $file is empty or does not exist
+      fi # [ -s $file ]
 
-         if [ -s $file ]; then
-              cat $file >> nsstbufr
-              err_cat=$?
-            if [ $err_cat -ne 0 ]; then
-              msg="**WARNING: exit status $err_cat from cat of $file to nsstbufr"
-              $DATA/postmsg "$jlogfile" "$msg"
-            fi
-         else
-            echo $file is empty or does not exist
-         fi # [ -s $file ]
-
-      done # for type in $DTYPS_nsst
-   fi # [ -s nsstbufr ] 
+   done # for type in $DTYPS_nsst
    
    cp nsstbufr $COMOUT/${RUN}.${cycle}.nsstbufr
    chmod 664 $COMOUT/${RUN}.${cycle}.nsstbufr
 
    if [ "$CHGRP_RSTPROD" = 'YES' ]; then
+      chgrp rstprod nsstbufr
       chgrp rstprod $COMOUT/${RUN}.${cycle}.nsstbufr
       err_ch=$?
       if [ $err_ch -eq 0 ]; then
+	 chmod 640 nsstbufr
          chmod 640 $COMOUT/${RUN}.${cycle}.nsstbufr
 	 msg="NOTE: nsstbufr file contains RESTRICTED data, only users in \
 rstprod group have read permission"
          $DATA/postmsg "$jlogfile" "$msg"
+      else
+         cp /dev/null nsstbufr
+	 cp /dev/null $COMOUT/${RUN}.${cycle}.nsstbufr
+	 warning=yes
       fi
    fi # if [ "CHGRP_RSTPROD" = 'YES' ]
 


### PR DESCRIPTION
Reorganized `MAKE_NSSTBUFR` block to check `CHGRP_RSTPROD`. Since the restricted data is not used on the cloud at this time, `CHGRP_RSTPROD` is defaulted to NO for cloud environments. Previously, the NSST buffer file was only created if `chgrp rstprod` command is successful causing the NSST buffer file to be empty when made on the cloud using unrestricted data.

Tested this change within the prep steps of the global-workflow C96_atm3DVar test on Hera (with `CHGRP_RSTPROD='YES'`) and NOAA cloud AWS (with `CHGRP_RSTPROD='YES'` to check null file is created in place of NSST buffer file when `chgrp rstprod` command fails and with `CHGRP_RSTPROD='NO'`). Associated log files and resulting NSST buffer files for both environments can be found on Hera in `/scratch1/BMC/qosap/Taylor.Roper/shared` (labeled `*.hera` and `*.cloud` respectively).

Resolves #101 